### PR TITLE
Fix loop variable leaking into global environment

### DIFF
--- a/pkg/debian/postinst
+++ b/pkg/debian/postinst
@@ -12,8 +12,10 @@ case "$1" in
             cat >> "$RPROFILE" << 'EOF'
 
 # Source /etc/R/profile.d/ drop-in scripts
-for (f in list.files("/etc/R/profile.d", pattern = "\\.R$", full.names = TRUE))
-    source(f)
+local({
+    for (f in list.files("/etc/R/profile.d", pattern = "\\.R$", full.names = TRUE))
+        source(f, local = FALSE)
+})
 EOF
         fi
         ;;


### PR DESCRIPTION
## Summary
- The `for` loop in the `profile.d` sourcing block (appended to `/etc/R/Rprofile.site`) leaks the variable `f` into the user's global environment
- Wrapping in `local()` contains the loop variable while `source(f, local = FALSE)` preserves the original behavior of executing scripts in the global env

## Test plan
- [ ] Install updated package, confirm `f` no longer appears in `ls()` on RStudio startup
- [ ] Confirm `rapt::enable()` still runs correctly via the profile.d drop-in