### PR TITLE
Add package building and upload to main ci job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: eddelbuettel/github-actions/r-ci@master
 
       - name: Debian Dependencies
-        run: run.sh install_aptget debhelper
+        run: ./run.sh install_aptget debhelper
 
       - name: Debian Build
         run: cd pkg && dpkg-buildpackage -rfakeroot -us -uc -b -tc

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,9 @@
 name: ci
 
 on:
+  push:
   pull_request:
+  workflow_dispatch:
 
 env:
   _R_CHECK_FORCE_SUGGESTS_: "false"
@@ -11,18 +13,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup
         uses: eddelbuettel/github-actions/r-ci@master
 
       - name: Dependencies
+        # Direct call instead of relying on 'run.sh install_deps'
+        # as the DESCRIPTION file is in subdirectory r-pkg
         run: ./run.sh install_r tinytest
 
       - name: Build
+        # Direct call of build instead of relying on 'run.sh run_tests'
+        # as the packages is in subdirectory r-pkg
         run: R CMD build r-pkg
 
       - name: Check
+        # Direct call of tests instead of relying on 'run.sh run_tests'
+        # as the packages is in subdirectory r-pkg
         run: R CMD check rapt_*.tar.gz --no-manual
 
       - name: Test
@@ -34,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Build daemon
         run: make -C daemon
@@ -43,3 +51,22 @@ jobs:
         run: |
           ./daemon/raptd --help || true
           file ./daemon/raptd
+
+  deb-package:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup
+        uses: eddelbuettel/github-actions/r-ci@master
+
+      - name: Debian Dependencies
+        run: run.sh install_aptget debhelper
+
+      - name: Debian Build
+        run: cd pkg && dpkg-buildpackage -rfakeroot -us -uc -b -tc
+
+      - name: Check Package
+        run: dpkg -c rapt_*.deb
+        

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: ci
 
 on:
-  #push:
+  push:
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: ci
 
 on:
-  push:
+  #push:
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,5 +79,5 @@ jobs:
       - name: Upload Package
         uses: actions/upload-artifact@v7
         with:
-          name: r_package
+          name: deb_package
           path: rapt_*.deb

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,12 @@ jobs:
           R CMD INSTALL rapt_*.tar.gz
           Rscript -e 'tinytest::test_package("rapt")'
 
+      - name: Upload
+        uses: actions/upload-artifact@v7
+        with:
+          name: r_package
+          path: rapt_*.tar.gz
+
   daemon:
     runs-on: ubuntu-latest
 
@@ -70,3 +76,8 @@ jobs:
       - name: Check Package
         run: dpkg -c rapt_*.deb
         
+      - name: Upload Package
+        uses: actions/upload-artifact@v7
+        with:
+          name: r_package
+          path: rapt_*.deb

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
         uses: eddelbuettel/github-actions/r-ci@master
 
       - name: Debian Dependencies
-        run: ./run.sh install_aptget debhelper
+        run: ./run.sh install_aptget debhelper apt-utils
 
       - name: Debian Build
         run: cd pkg && dpkg-buildpackage -rfakeroot -us -uc -b -tc
@@ -81,3 +81,14 @@ jobs:
         with:
           name: deb_package
           path: rapt_*.deb
+
+      - name: Update Repository
+        run: |
+          cp -vax rapt_*.deb docs/
+          cd docs/
+          apt-ftparchive packages . > Packages
+          cat Packages | gzip > Packages.gz
+          apt-ftparchive -c repo.conf release . > Release
+          # InRelease and Packages should be signed, ideally
+          cp -vax Release InRelease
+          ls -l

--- a/docs/repo.conf
+++ b/docs/repo.conf
@@ -1,0 +1,3 @@
+APT::FTPArchive::Release::Origin "cornball-ai rapt repository";
+APT::FTPArchive::Release::Label "ppa for rapt";
+APT::FTPArchive::Release::Architectures "amd64 all";


### PR DESCRIPTION
To be discussed where we ultimately want the artifacts: as 'releases'?  As binaries committed back?  In a tailscale network?