### PR TITLE
Allow suppression of the default message() in enable()

### DIFF
--- a/r-pkg/R/integration.R
+++ b/r-pkg/R/integration.R
@@ -15,6 +15,9 @@
 #' This is called automatically at startup when rapt is installed via
 #' the Debian package (via \code{/etc/R/profile.d/rapt.R}).
 #'
+#' Option \sQuote{rapt.verbose} can be set to \sQuote{FALSE} to suppress
+#' the message.
+#'
 #' @return Invisible \code{NULL}.
 #' @examples
 #' \dontrun{
@@ -71,7 +74,8 @@ enable <- function() {
     if (was_locked) lockBinding("install.packages", ns)
 
     options(rapt.enabled = TRUE)
-    message("rapt enabled - install.packages() will use apt when possible")
+    if (getOption("rapt.verbose", TRUE))
+        message("rapt enabled - install.packages() will use apt when possible")
     invisible(NULL)
 }
 

--- a/r-pkg/R/integration.R
+++ b/r-pkg/R/integration.R
@@ -15,9 +15,9 @@
 #' This is called automatically at startup when rapt is installed via
 #' the Debian package (via \code{/etc/R/profile.d/rapt.R}).
 #'
-#' Option \sQuote{rapt.verbose} can be set to \sQuote{FALSE} to suppress
-#' the message.
-#'
+#' @param verbose logical with default value supplied by option
+#' \sQuote{rapt.verbose} with a fallback of \sQuote{TRUE} to suppress
+#' a message from this function.
 #' @return Invisible \code{NULL}.
 #' @examples
 #' \dontrun{
@@ -27,7 +27,7 @@
 #' }
 #' @seealso \code{\link{disable}}, \code{\link{manager}}
 #' @export
-enable <- function() {
+enable <- function(verbose = getOption("rapt.verbose", TRUE)) {
     if (isTRUE(getOption("rapt.enabled"))) {
         message("rapt already enabled")
         return(invisible(NULL))
@@ -74,8 +74,7 @@ enable <- function() {
     if (was_locked) lockBinding("install.packages", ns)
 
     options(rapt.enabled = TRUE)
-    if (getOption("rapt.verbose", TRUE))
-        message("rapt enabled - install.packages() will use apt when possible")
+    if (verbose) message("rapt enabled - install.packages() will use apt when possible")
     invisible(NULL)
 }
 

--- a/r-pkg/R/integration.R
+++ b/r-pkg/R/integration.R
@@ -15,9 +15,9 @@
 #' This is called automatically at startup when rapt is installed via
 #' the Debian package (via \code{/etc/R/profile.d/rapt.R}).
 #'
-#' @param verbose logical with default value supplied by option
-#' \sQuote{rapt.verbose} with a fallback of \sQuote{TRUE} to suppress
-#' a message from this function.
+#' @param verbose logical controlling whether this function reports what
+#' it did, defaulting to option \sQuote{rapt.verbose} and to \sQuote{TRUE}
+#' when that option is unset. Set to \sQuote{FALSE} for silence.
 #' @return Invisible \code{NULL}.
 #' @examples
 #' \dontrun{
@@ -29,7 +29,7 @@
 #' @export
 enable <- function(verbose = getOption("rapt.verbose", TRUE)) {
     if (isTRUE(getOption("rapt.enabled"))) {
-        message("rapt already enabled")
+        if (verbose) message("rapt already enabled")
         return(invisible(NULL))
     }
 
@@ -83,6 +83,9 @@ enable <- function(verbose = getOption("rapt.verbose", TRUE)) {
 #' Restores the original \code{install.packages()} function so packages
 #' are installed from CRAN instead of apt.
 #'
+#' @param verbose logical controlling whether this function reports what
+#' it did, defaulting to option \sQuote{rapt.verbose} and to \sQuote{TRUE}
+#' when that option is unset. Set to \sQuote{FALSE} for silence.
 #' @return Invisible \code{NULL}.
 #' @examples
 #' \dontrun{
@@ -91,9 +94,9 @@ enable <- function(verbose = getOption("rapt.verbose", TRUE)) {
 #' }
 #' @seealso \code{\link{enable}}
 #' @export
-disable <- function() {
+disable <- function(verbose = getOption("rapt.verbose", TRUE)) {
     if (!isTRUE(getOption("rapt.enabled"))) {
-        message("rapt not enabled")
+        if (verbose) message("rapt not enabled")
         return(invisible(NULL))
     }
 
@@ -111,6 +114,6 @@ disable <- function() {
 
     .rapt_env$original_install.packages <- NULL
     options(rapt.enabled = FALSE)
-    message("rapt disabled - install.packages() restored to original")
+    if (verbose) message("rapt disabled - install.packages() restored to original")
     invisible(NULL)
 }

--- a/r-pkg/man/disable.Rd
+++ b/r-pkg/man/disable.Rd
@@ -3,7 +3,12 @@
 \alias{disable}
 \title{Disable rapt integration}
 \usage{
-disable()
+disable(verbose = getOption("rapt.verbose", TRUE))
+}
+\arguments{
+\item{verbose}{logical controlling whether this function reports what
+it did, defaulting to option \sQuote{rapt.verbose} and to \sQuote{TRUE}
+when that option is unset. Set to \sQuote{FALSE} for silence.}
 }
 \value{
 Invisible \code{NULL}.

--- a/r-pkg/man/enable.Rd
+++ b/r-pkg/man/enable.Rd
@@ -6,9 +6,9 @@
 enable(verbose = getOption("rapt.verbose", TRUE))
 }
 \arguments{
-\item{verbose}{logical with default value supplied by option
-\sQuote{rapt.verbose} with a fallback of \sQuote{TRUE} to suppress
-a message from this function.}
+\item{verbose}{logical controlling whether this function reports what
+it did, defaulting to option \sQuote{rapt.verbose} and to \sQuote{TRUE}
+when that option is unset. Set to \sQuote{FALSE} for silence.}
 }
 \value{
 Invisible \code{NULL}.

--- a/r-pkg/man/enable.Rd
+++ b/r-pkg/man/enable.Rd
@@ -17,8 +17,14 @@ packages available in the r2u repository. When enabled, calls to
 \item Install those packages via \code{install_sys()}
 \item Install remaining packages from CRAN as usual
 }
+}
+\details{
 This is called automatically at startup when rapt is installed via
 the Debian package (via \code{/etc/R/profile.d/rapt.R}).
+
+Option \sQuote{rapt.verbose} can be set to \sQuote{FALSE} to suppress
+the message.
+
 }
 \examples{
 \dontrun{

--- a/r-pkg/man/enable.Rd
+++ b/r-pkg/man/enable.Rd
@@ -3,7 +3,12 @@
 \alias{enable}
 \title{Enable rapt integration}
 \usage{
-enable()
+enable(verbose = getOption("rapt.verbose", TRUE))
+}
+\arguments{
+\item{verbose}{logical with default value supplied by option
+\sQuote{rapt.verbose} with a fallback of \sQuote{TRUE} to suppress
+a message from this function.}
 }
 \value{
 Invisible \code{NULL}.
@@ -21,9 +26,6 @@ packages available in the r2u repository. When enabled, calls to
 \details{
 This is called automatically at startup when rapt is installed via
 the Debian package (via \code{/etc/R/profile.d/rapt.R}).
-
-Option \sQuote{rapt.verbose} can be set to \sQuote{FALSE} to suppress
-the message.
 
 }
 \examples{

--- a/r-pkg/man/socket.Rd
+++ b/r-pkg/man/socket.Rd
@@ -1,7 +1,0 @@
-% tinyrox says don't edit this manually, but it can't stop you!
-\name{socket}
-\alias{socket}
-\title{Low-level socket communication with raptd}
-\description{
-Internal functions for communicating with the rapt daemon.
-}


### PR DESCRIPTION
A very simple PR to make the `message()` from `enable()` optional.  Could be altered / extended to have `enable()` have an option `verbose` taking the `option()` as default.