### PR TITLE
Fold publish into deb-package and drop the artifact round trip

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,24 @@ jobs:
   deb-package:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
+    # Publishes share one group so they serialise, as two of them would both
+    # regenerate docs/ and race to push, and the loser cannot rebase its way
+    # out because the conflicting files are a .deb and a gzip. Ordinary builds
+    # get a group per ref so pull requests still run in parallel.
+    concurrency:
+      group: ${{ (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')) && 'publish' || format('build-{0}', github.ref) }}
+      cancel-in-progress: false
+
+    env:
+      PUBLISH: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') }}
+      # A dispatch publishes into the branch it was run against, so this can be
+      # tested before it reaches master. A tag build has nowhere of its own to
+      # push, as it checks out a detached HEAD, so it targets master.
+      TARGET: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'master' }}
+
     steps:
       - uses: actions/checkout@v7
 
@@ -106,57 +124,26 @@ jobs:
       - name: Check Package
         run: dpkg -c rapt_*.deb
 
-      - name: Upload Package
-        uses: actions/upload-artifact@v7
-        with:
-          name: deb_package
-          path: rapt_*.deb
-
-      # Dry run: proves the repository still builds on every pull request.
-      # The 'publish' job below does the same thing for real.
+      # Dry run, so a pull request still proves the repository builds. The
+      # publish steps below do the real thing against the target branch.
       - name: Update Repository
+        if: env.PUBLISH != 'true'
         run: tools/mkrepo.sh rapt_*.deb
 
-  publish:
-    needs: deb-package
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
-
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-
-    # Two publishes at once would both regenerate docs/ and race to push, and
-    # the loser cannot rebase its way out because the conflicting files are a
-    # .deb and a gzip. Serialise per target branch instead.
-    concurrency:
-      group: publish-${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'master' }}
-      cancel-in-progress: false
-
-    env:
-      # A dispatch publishes into the branch it was run against, so this job
-      # can be tested before it reaches master. A tag build has nowhere to
-      # push, as it checks out a detached HEAD, so it targets master.
-      TARGET: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'master' }}
-
-    steps:
-      - uses: actions/checkout@v7
+      # The target branch goes in a subdirectory because the build above may be
+      # sitting on a tag, and a detached HEAD has no branch to push back to.
+      - name: Checkout Target
+        if: env.PUBLISH == 'true'
+        uses: actions/checkout@v7
         with:
           ref: ${{ env.TARGET }}
+          path: target
 
-      - name: Fetch Package
-        uses: actions/download-artifact@v8
-        with:
-          name: deb_package
-
-      - name: Dependencies
-        run: sudo apt-get install -y apt-utils
-
-      - name: Update Repository
-        run: tools/mkrepo.sh rapt_*.deb
-
-      - name: Commit and Push
+      - name: Publish Repository
+        if: env.PUBLISH == 'true'
         run: |
+          target/tools/mkrepo.sh rapt_*.deb
+          cd target
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,14 +66,6 @@ jobs:
     permissions:
       contents: write
 
-    # Publishes share one group so they serialise, as two of them would both
-    # regenerate docs/ and race to push, and the loser cannot rebase its way
-    # out because the conflicting files are a .deb and a gzip. Ordinary builds
-    # get a group per ref so pull requests still run in parallel.
-    concurrency:
-      group: ${{ (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')) && 'publish' || format('build-{0}', github.ref) }}
-      cancel-in-progress: false
-
     env:
       PUBLISH: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') }}
       # A dispatch publishes into the branch it was run against, so this can be
@@ -130,20 +122,15 @@ jobs:
         if: env.PUBLISH != 'true'
         run: tools/mkrepo.sh rapt_*.deb
 
-      # The target branch goes in a subdirectory because the build above may be
-      # sitting on a tag, and a detached HEAD has no branch to push back to.
-      - name: Checkout Target
-        if: env.PUBLISH == 'true'
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ env.TARGET }}
-          path: target
-
       - name: Publish Repository
         if: env.PUBLISH == 'true'
         run: |
-          target/tools/mkrepo.sh rapt_*.deb
-          cd target
+          # A tag build sits on a detached HEAD with no branch to push back to,
+          # so land on the target branch first. The .deb built above is
+          # untracked and survives the switch.
+          git fetch --depth=1 origin "${TARGET}"
+          git checkout -B "${TARGET}" FETCH_HEAD
+          tools/mkrepo.sh rapt_*.deb
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A docs


### PR DESCRIPTION
Picks up @eddelbuettel's note on #17 that the `Upload Package` step is
vestigial now that there is an apt repository.

It could not simply be deleted, because `publish` pulled that artifact with
`download-artifact`. Removing it properly means one job instead of two, which
this does.

### What improves

The `.deb` that reaches the repository is now trivially the same file that
`Check Package` inspected, rather than a copy that made a round trip through
artifact storage. Given how much of #17 was about making sure a published
version always corresponds to exactly one set of bytes, that is the right
property to have structurally rather than by argument.

`mkrepo.sh` needed no changes. It resolves `docs/` from its own location, so
calling `target/tools/mkrepo.sh rapt_*.deb` from the workspace root copies into
the target checkout. Verified locally.

### What gets worse, honestly

I proposed this on #17 and am less sure it is a clear win having built it.

1. **`contents: write` now covers the whole job**, including pull request
   builds, where it used to be scoped to `publish` alone. Fork pull requests
   still get a read-only token from GitHub regardless, but a same-repo PR
   branch now builds with a write-scoped token it does not need.
2. **The concurrency expression became a nested ternary.** Publishes have to
   share one group to serialise, while ordinary builds need a group per ref so
   pull requests still run in parallel. Two jobs expressed that with one plain
   string.
3. **Three steps carry `if:` conditions** where one job-level `if:` used to do
   the same work.
4. **No downloadable `.deb` on pull requests** any more. Minor, but a reviewer
   wanting to test a change now has to build one.

Point 1 is the one I would weigh. The other three are legibility.

### Not tested end to end

The publish path here has not been exercised, only the dry run and the local
path check. Proving it means dispatching against this branch, which commits a
snapshot into it, and reverting that before merge. Happy to do that if wanted.
