### PR TITLE
Quiet the startup hook by default

### DIFF
--- a/pkg/debian/copyright
+++ b/pkg/debian/copyright
@@ -4,7 +4,7 @@ Upstream-Contact: Troy Hernandez <troy@cornball.ai>
 Source: https://github.com/cornball-ai/rapt
 
 Files: *
-Copyright: 2026 Troy Hernandez <troy@cornball.ai>
+Copyright: 2026 cornball.ai
 License: MIT
 
 License: MIT

--- a/pkg/debian/rapt.R
+++ b/pkg/debian/rapt.R
@@ -1,2 +1,8 @@
-## Enable rapt if installed
-if (requireNamespace("rapt", quietly = TRUE)) rapt::enable()
+## Enable rapt if installed.
+##
+## Quiet by default, as a system-wide hook should not announce itself in every
+## session. Set RAPT_VERBOSE=TRUE to hear about it. An environment variable
+## rather than an option, because R reads ~/.Renviron before any profile file,
+## so this stays settable without root.
+if (requireNamespace("rapt", quietly = TRUE))
+    rapt::enable(verbose = identical(toupper(Sys.getenv("RAPT_VERBOSE")), "TRUE"))

--- a/pkg/debian/rapt.R
+++ b/pkg/debian/rapt.R
@@ -5,4 +5,4 @@
 ## rather than an option, because R reads ~/.Renviron before any profile file,
 ## so this stays settable without root.
 if (requireNamespace("rapt", quietly = TRUE))
-    rapt::enable(verbose = identical(toupper(Sys.getenv("RAPT_VERBOSE")), "TRUE"))
+    rapt::enable(verbose = identical(toupper(Sys.getenv("RAPT_VERBOSE", "FALSE")), "TRUE"))

--- a/r-pkg/DESCRIPTION
+++ b/r-pkg/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rapt
 Type: Package
 Title: Bridge 'install.packages()' to 'apt' for Binary R Packages
-Version: 0.1.0
+Version: 0.1.0.1
 Authors@R: person("Troy", "Hernandez", role = c("aut", "cre"),
                   email = "troy@cornball.ai")
 Description: Enables 'install.packages()' to install R packages via apt,

--- a/r-pkg/DESCRIPTION
+++ b/r-pkg/DESCRIPTION
@@ -5,6 +5,9 @@ Version: 0.1.0.1
 Authors@R: c(person("Troy", "Hernandez", role = c("aut", "cre"),
                     email = "troy@cornball.ai",
                     comment = c(ORCID = "0009-0005-4248-604X")),
+             person("Dirk", "Eddelbuettel", role = "ctb",
+                    email = "edd@debian.org",
+                    comment = c(ORCID = "0000-0001-6419-907X")),
              person("cornball.ai", role = "cph"))
 Description: Enables 'install.packages()' to install R packages via apt,
     providing fast binary installs from r2u repositories. Communicates with

--- a/r-pkg/DESCRIPTION
+++ b/r-pkg/DESCRIPTION
@@ -2,8 +2,10 @@ Package: rapt
 Type: Package
 Title: Bridge 'install.packages()' to 'apt' for Binary R Packages
 Version: 0.1.0.1
-Authors@R: person("Troy", "Hernandez", role = c("aut", "cre"),
-                  email = "troy@cornball.ai")
+Authors@R: c(person("Troy", "Hernandez", role = c("aut", "cre"),
+                    email = "troy@cornball.ai",
+                    comment = c(ORCID = "0009-0005-4248-604X")),
+             person("cornball.ai", role = "cph"))
 Description: Enables 'install.packages()' to install R packages via apt,
     providing fast binary installs from r2u repositories. Communicates with
     the raptd daemon over a Unix socket. A Python-free alternative to 'bspm'.

--- a/r-pkg/LICENSE
+++ b/r-pkg/LICENSE
@@ -1,21 +1,2 @@
-MIT License
-
-Copyright (c) 2026 Troy Hernandez
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+YEAR: 2026
+COPYRIGHT HOLDER: cornball.ai

--- a/r-pkg/NEWS.md
+++ b/r-pkg/NEWS.md
@@ -7,7 +7,7 @@
   `RAPT_VERBOSE=TRUE` to restore the startup message.
 
 * Binary packages are published to an apt repository at
-  <https://cornball-ai.github.io/rapt> (#17).
+  <https://cornball-ai.github.io/rapt/> (#17).
 
 # rapt 0.1.0
 

--- a/r-pkg/NEWS.md
+++ b/r-pkg/NEWS.md
@@ -1,0 +1,14 @@
+# rapt 0.1.0.1
+
+* `enable()` and `disable()` gained a `verbose` argument, defaulting to option
+  `rapt.verbose` (#20, thanks to @eddelbuettel).
+
+* The `/etc/R/profile.d/rapt.R` drop-in is quiet by default. Set
+  `RAPT_VERBOSE=TRUE` to restore the startup message.
+
+* Binary packages are published to an apt repository at
+  <https://cornball-ai.github.io/rapt> (#17).
+
+# rapt 0.1.0
+
+* Initial release.


### PR DESCRIPTION
Finishes what #20 started.

#20 gave `enable()` and `disable()` a `verbose` argument, which covers every
call site a caller controls. The one it could not reach is the drop-in this
package ships, because the option would have to be set before `Rprofile.site`
sources `profile.d`, and no user-writable file runs that early.

An environment variable does, since R reads `~/.Renviron` before any profile.
So `/etc/R/profile.d/rapt.R` becomes:

```r
if (requireNamespace("rapt", quietly = TRUE))
    rapt::enable(verbose = identical(toupper(Sys.getenv("RAPT_VERBOSE")), "TRUE"))
```

Quiet by default, on the grounds that a system-wide hook should not announce
itself in every session, which is the noise that prompted #20. `RAPT_VERBOSE=TRUE`
restores the message without root, and works as `ENV RAPT_VERBOSE=TRUE` in a
Dockerfile.

This uses the argument from #20 rather than wrapping the call in
`suppressMessages()`, so the two mechanisms are the same mechanism.

Verified all four states: unset and `FALSE` are silent, `TRUE` and `true` both
speak.

The file is a registered conffile, so anyone who had edited it locally would get
the usual dpkg prompt on upgrade. Nobody has, the package being a day old.

Second commit bumps to `0.1.0.1` and adds a NEWS.md, since master has been ahead
of the `v0.1.0` tag since #20 landed.
