### PR TITLE
Source both .r and .R in startup for Rprofile.site

### DIFF
--- a/pkg/debian/postinst
+++ b/pkg/debian/postinst
@@ -13,7 +13,7 @@ case "$1" in
 
 # Source /etc/R/profile.d/ drop-in scripts
 local({
-    for (f in list.files("/etc/R/profile.d", pattern = "\\.R$", full.names = TRUE))
+    for (f in list.files("/etc/R/profile.d", pattern = "\\.[rR]$", full.names = TRUE))
         source(f, local = FALSE)
 })
 EOF


### PR DESCRIPTION
Closes #19 

Quick and minimal PR to allow snippets to end in both .r and .R as suggested in #19.